### PR TITLE
Philip's suggestions

### DIFF
--- a/XSD/SA-UC1-11-02-2021.xsd
+++ b/XSD/SA-UC1-11-02-2021.xsd
@@ -1,8 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- edited with XMLSpy v2021 (x64) (http://www.altova.com) by Peter Bruhn Andersen (Digitaliseringsstyrelsen) -->
-<xsd:schema elementFormDefault="qualified" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:cvb="http://www.w3.org/ns/corevocabulary/BasicComponents" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:udt="urn:un:unece:uncefact:data:specification:UnqualifiedDataTypesSchemaModule:2" xmlns:cred="http://data.europa.eu/europass/model/credentials/w3c#" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sa="https://data.europe.eu/de4a/model/studying-abroad/" xmlns:edci="http://data.europa.eu/europass/model/credentials#" targetNamespace="https://data.europe.eu/de4a/model/studying-abroad/">
+<xsd:schema elementFormDefault="qualified"
+			xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+			xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+			xmlns:udt="urn:un:unece:uncefact:data:specification:UnqualifiedDataTypesSchemaModule:2"
+			xmlns:sa="urn:eu-de4a:xsd:CanonicalEvidenceType::StudyingAbroad:v1.0"
+			xmlns:edci="http://data.europa.eu/europass/model/credentials#"
+			targetNamespace="urn:eu-de4a:xsd:CanonicalEvidenceType::StudyingAbroad:v1.0">
 	<xsd:import namespace="http://data.europa.eu/europass/model/credentials#" schemaLocation="edci_credentialTypes.xsd"/>
-	<!--<xsd:import namespace="http://data.europa.eu/europass/model/credentials#" schemaLocation="edci_agent.xsd"/>-->
 	<xsd:import namespace="http://www.w3.org/ns/corevocabulary/BasicComponents" schemaLocation="CoreVocabularyBasicComponents-v1.00.xsd"/>
 	<xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" schemaLocation="common/UBL-CommonBasicComponents-2.0.xsd"/>
 	<xsd:import namespace="urn:un:unece:uncefact:data:specification:UnqualifiedDataTypesSchemaModule:2" schemaLocation="common/UnqualifiedDataTypeSchemaModule-2.0.xsd"/>


### PR DESCRIPTION
Revised XSD based on Philip's suggestions:
- Added elementFormDefault="qualified"
- Adopted target namespace URL from "https://data.europe.eu/de4a/model/studying-abroad" to the URN form.
- Renamed element "durationOfEducation" to the more granular "monthsOfEducation". 